### PR TITLE
fix: use json in registration message payload

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -47,7 +47,7 @@ static esp_err_t mqtt_event_handler_cb(esp_mqtt_event_handle_t event)
     switch (event->event_id) {
         case MQTT_EVENT_CONNECTED:    // 
             ESP_LOGI(TAG, "MQTT_EVENT_CONNECTED");
-            msg_id = esp_mqtt_client_publish(client, topic_identifier, "{'name': 'esp32-c-client','type': 'ESP-IDF','@type': 'child-device'}", 0, 1, 0);
+            msg_id = esp_mqtt_client_publish(client, topic_identifier, "{\"name\":\"esp32-c-client\",\"type\":\"ESP-IDF\",\"@type\":\"child-device\"}", 0, 1, 0);
             ESP_LOGI(TAG, "sent publish successful, msg_id=%d", msg_id);
             msg_id = esp_mqtt_client_publish(client, "te/device/esp32-c-client///twin/c8y_Hardware", "{\"model\": \"esp32-WROOM-32\",\"revision\": \"esp32\",\"serialNumber\": \"ESP32\"}", 0, 1, 0);
             ESP_LOGI(TAG, "sent publish successful, msg_id=%d", msg_id);


### PR DESCRIPTION
Use double quotes instead of single quotes so that the registration message is valid json, otherwise it will be ignored by thin-edge.io