### PR TITLE
feat: derive child id from the wifi mac address

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -9,6 +9,7 @@
 #include "nvs_flash.h"
 #include "esp_event.h"
 #include "esp_netif.h"
+#include "esp_mac.h"
 #include "protocol_examples_common.h"
 
 
@@ -24,47 +25,81 @@
 #include "esp_log.h"
 #include "mqtt_client.h"
 
-static const char *TAG = "MQTT_EXAMPLE";
+static const char *TAG = "TEDGE";
 char APPLICATION_VERSION[] = "1.1.1";
+char DEVICE_ID[32] = {0};
+char TOPIC_ID[256] = {0};
 char *cmd_topic;
 char *cmd_data;
 char *restart_cmd[20];
 
+/* 
+    Set the device identify and topic identifier.
+    The MAC address from the Wifi is used to unique identify the device
+*/
+void set_device_id(char *device_id, char *topic_id) {
+    unsigned char mac[6] = {0};
+    esp_efuse_mac_get_default(mac);
+    esp_read_mac(mac, ESP_MAC_WIFI_STA);
+    sprintf(device_id, "esp32-%02x%02x%02x%02x%02x%02x", mac[0],mac[1],mac[2],mac[3],mac[4],mac[5]);
+    sprintf(topic_id, "te/device/%s//", device_id);
+}
+
+/*
+    Publish an MQTT message to the device's topic identifier
+*/
+int publish_mqtt_message(esp_mqtt_client_handle_t client, const char *topic, const char *data, int len, int qos, int retain) {
+    char full_topic[256] = {0};
+    strcat(full_topic, TOPIC_ID);
+    strcat(full_topic, topic);
+    ESP_LOGI(TAG, "Publishing message. topic=%s, data=%s", full_topic, data);
+    int msg_id = esp_mqtt_client_publish(client, full_topic, data, len, qos, retain);
+    ESP_LOGI(TAG, "sent publish successful, msg_id=%d", msg_id);
+    return msg_id;
+}
+
+/*
+    Build mqtt topic using the device's topic identifier and the give partial topic
+*/
+void build_mqtt_topic(char *dst, char *topic) {
+    strcat(dst, TOPIC_ID);
+    strcat(dst, topic);
+}
 
 static esp_err_t mqtt_event_handler_cb(esp_mqtt_event_handle_t event)
 {
 
     esp_mqtt_client_handle_t client = event->client;
-    int msg_id;
-    char topic_identifier[] = "te/device/";
-    char DEVICE_ID[] = "esp32-c-client";
-    strcat( topic_identifier, DEVICE_ID);
-    strcat( topic_identifier, "//");
     time_t t;
     srand((unsigned) time(&t));
 
     switch (event->event_id) {
         case MQTT_EVENT_CONNECTED:
             ESP_LOGI(TAG, "MQTT_EVENT_CONNECTED");
-            msg_id = esp_mqtt_client_publish(client, topic_identifier, "{\"name\":\"esp32-c-client\",\"type\":\"ESP-IDF\",\"@type\":\"child-device\"}", 0, 1, 0);
-            ESP_LOGI(TAG, "sent publish successful, msg_id=%d", msg_id);
-            msg_id = esp_mqtt_client_publish(client, "te/device/esp32-c-client///twin/c8y_Hardware", "{\"model\": \"esp32-WROOM-32\",\"revision\": \"esp32\",\"serialNumber\": \"ESP32\"}", 0, 1, 0);
-            ESP_LOGI(TAG, "sent publish successful, msg_id=%d", msg_id);
-            msg_id = esp_mqtt_client_publish(client, "te/device/esp32-c-client///cmd/restart", "", 0, 1, 0);
-            ESP_LOGI(TAG, "sent publish successful, msg_id=%d", msg_id);
-            // TODO:
-            // char payload[] = "{\"text\": \"Application started. version=";
-            // strcat(payload, APPLICATION_VERSION);
-            // strcat( payload, "\"}");
-            // printf("%s\n", payload);
-            // msg_id = esp_mqtt_client_publish(client, "te/device/esp32-c-client///e/boot", payload, 0, 1, 1);
-            // ESP_LOGI(TAG, "sent publish successful, msg_id=%d", msg_id);
-            msg_id = esp_mqtt_client_subscribe(client, "te/device/esp32-c-client///cmd/+/+", 0);
-            ESP_LOGI(TAG, "sent subscribe successful, msg_id=%d", msg_id);
-            // msg_id = esp_mqtt_client_subscribe(client, "/topic/qos1", 1);
-            // ESP_LOGI(TAG, "sent subscribe successful, msg_id=%d", msg_id);
-            // msg_id = esp_mqtt_client_unsubscribe(client, "/topic/qos1");
-            // ESP_LOGI(TAG, "sent unsubscribe successful, msg_id=%d", msg_id);
+
+            // Register device
+            char reg_message[256] = {0};
+            sprintf(reg_message, "{\"name\":\"%s\",\"type\":\"ESP-IDF\",\"@type\":\"child-device\"}", DEVICE_ID);
+            publish_mqtt_message(client, "", reg_message, 0, 1, 1);
+
+            // Publish device info
+            char hardware_info[256] = {0};
+            sprintf(hardware_info, "{\"model\":\"esp32-WROOM-32\",\"revision\":\"esp32\",\"serialNumber\":\"%s\"}", DEVICE_ID);
+            publish_mqtt_message(client, "/twin/c8y_Hardware", hardware_info, 0, 1, 1);
+
+            // Register capabilities
+            publish_mqtt_message(client, "/cmd/restart", "{}", 0, 1, 1);
+
+            // Publish boot event
+            char boot_message[256] = {0};
+            sprintf(boot_message, "{\"text\":\"Application started. version=%s\",\"version\":\"%s\"}", APPLICATION_VERSION, APPLICATION_VERSION);
+            publish_mqtt_message(client, "/e/boot", boot_message, 0, 1, 0);
+
+            // Subscribe to commands
+            char command_topic[256] = {0};
+            build_mqtt_topic(command_topic, "/cmd/+/+");
+            int msg_id = esp_mqtt_client_subscribe(client, command_topic, 0);
+            ESP_LOGI(TAG, "sent subscribe successful, topic=%s msg_id=%d", command_topic, msg_id);
             break;
         case MQTT_EVENT_DISCONNECTED:
             ESP_LOGI(TAG, "MQTT_EVENT_DISCONNECTED");
@@ -72,22 +107,16 @@ static esp_err_t mqtt_event_handler_cb(esp_mqtt_event_handle_t event)
 
         case MQTT_EVENT_SUBSCRIBED:
             ESP_LOGI(TAG, "MQTT_EVENT_SUBSCRIBED, msg_id=%d", event->msg_id);
-            // msg_id = esp_mqtt_client_publish(client, "/topic/qos0", "data", 0, 0, 0);
-            // ESP_LOGI(TAG, "sent publish successful, msg_id=%d", msg_id);
             break;
         case MQTT_EVENT_UNSUBSCRIBED:
             ESP_LOGI(TAG, "MQTT_EVENT_UNSUBSCRIBED, msg_id=%d", event->msg_id);
             break;
         case MQTT_EVENT_PUBLISHED:
-            // ESP_LOGI(TAG, "MQTT_EVENT_PUBLISHED, msg_id=%d", event->msg_id);
-            // printf("Something published.\n");
             break;
         case MQTT_EVENT_DATA:
             ESP_LOGI(TAG, "MQTT_EVENT_DATA");
-            printf("TOPIC=%.*s\r\n", event->topic_len, event->topic);
-            printf("DATA=%.*s\r\n", event->data_len, event->data);
-            printf("%d\n", event->data_len);
-            printf("%d\n", event->data_len > 0);
+            ESP_LOGI(TAG, "TOPIC=%.*s", event->topic_len, event->topic);
+            ESP_LOGI(TAG, "DATA=%.*s (len %d)", event->data_len, event->data, event->data_len);
             if ((event->data_len) > 0)
             {
                 if (cmd_topic != NULL)
@@ -100,32 +129,34 @@ static esp_err_t mqtt_event_handler_cb(esp_mqtt_event_handle_t event)
                     free(cmd_data);
                     cmd_data = NULL;
                 }
-                cmd_topic = strndup(event->topic, event->topic_len);
+                if (strnstr(event->topic, TOPIC_ID, event->topic_len) != NULL) {
+                    int topic_len = strlen(TOPIC_ID);
+                    cmd_topic = strndup(event->topic+topic_len, event->topic_len-topic_len);
+                } else {
+                    cmd_topic = strndup(event->topic, event->topic_len);
+                }
                 cmd_data = strndup(event->data, event->data_len);
-                printf("%s\n", cmd_topic);
-                printf("%s\n", cmd_data);
+                ESP_LOGI(TAG, "COMMAND_TOPIC=%s", cmd_topic);
+                ESP_LOGI(TAG, "COMMAND_DATA=%s", cmd_data);
 
                 if (strstr(cmd_topic, "cmd/restart")!=NULL && strstr(cmd_data, "init")!=NULL)
                 {
                     restart_cmd[0] = "init";
-                    printf("Got restart request init\n");
-                    printf("%s\n", restart_cmd[0]);
-                    printf("%s\n", cmd_topic);
+                    ESP_LOGI(TAG, "Got restart request init");
                 }
                 else if (strstr(cmd_topic, "cmd/restart")!=NULL && strstr(cmd_data, "executing")!=NULL)
                 {
                     restart_cmd[1] = "executing";
-                    printf("Got restart request executing\n");
-                    printf("%s\n", restart_cmd[1]);
+                    ESP_LOGI(TAG, "Got restart request executing");
                 }
                 else if (strstr(cmd_topic, "cmd/restart")!=NULL && strstr(cmd_data, "successful")!=NULL)
                 {
-                    printf("Got restart request successful\n");
+                    ESP_LOGI(TAG, "Got restart request successful");
                 }
             }
             else
             {
-                printf("Payload is empty.\n");
+                ESP_LOGI(TAG, "Payload is empty");
             }
             break;
         case MQTT_EVENT_ERROR:
@@ -180,13 +211,16 @@ static void mqtt_app_start(void)
     }
 #endif /* CONFIG_BROKER_URL_FROM_STDIN */
 
+    set_device_id(DEVICE_ID, TOPIC_ID);
+    ESP_LOGI(TAG, "Device id: %s", DEVICE_ID);
+    ESP_LOGI(TAG, "Topic id: %s", TOPIC_ID);
+
     esp_mqtt_client_handle_t client = esp_mqtt_client_init(&mqtt_cfg);
     esp_mqtt_client_register_event(client, ESP_EVENT_ANY_ID, mqtt_event_handler, client);
     esp_mqtt_client_start(client);
 
     while (1)
     {
-        int msg_id;
         int temperature = rand() % 100;
         char temp_payload[] = "{\"temp\": ";
         char temp[16];
@@ -194,32 +228,25 @@ static void mqtt_app_start(void)
         strcat(temp_payload, temp);
         strcat(temp_payload, "}");
 
-        msg_id = esp_mqtt_client_publish(client, "te/device/esp32-c-client///m/environment", temp_payload, 0, 0, 0);
-        ESP_LOGI(TAG, "sent publish successful, msg_id=%d", msg_id);
+        publish_mqtt_message(client, "/m/environment", temp_payload, 0, 0, 0);
         sleep(5);
 
         if ((restart_cmd[0] != '\0') && (restart_cmd[1] == '\0'))
         {
-            msg_id = esp_mqtt_client_publish(client, "te/device/esp32-c-client///a/restart", "{\"text\": \"Device will be restarted\",\"severity\": \"critical\"}", 0, 1, 1);
-            ESP_LOGI(TAG, "sent alarm successful, msg_id=%d", msg_id);
-            msg_id = esp_mqtt_client_publish(client, cmd_topic, "{\"status\": \"executing\"}", 0, 1, 1);
-            ESP_LOGI(TAG, "sent executing successful, msg_id=%d", msg_id);
+            publish_mqtt_message(client, "/a/restart", "{\"text\": \"Device will be restarted\",\"severity\": \"critical\"}", 0, 1, 1);
+            publish_mqtt_message(client, cmd_topic, "{\"status\": \"executing\"}", 0, 1, 1);
             sleep(5);
             esp_restart();
         }
         else if (restart_cmd[1] != '\0')
         {
-            printf("Will create event!!!\n");
-            esp_mqtt_client_publish(client, "te/device/esp32-c-client///e/restart","{\"text\": \"Device restarted\"}",0,0,0);
-            // ESP_LOGI(TAG, "sent event successful, msg_id=%d", msg_id);
-            printf("sent event successful\n");
-            esp_mqtt_client_publish(client, "te/device/esp32-c-client///a/restart", "", 0, 2, 1);
-            printf("Clear alarm successful\n");
+            ESP_LOGI(TAG, "Will create event!!!");
+            publish_mqtt_message(client, "/e/restart","{\"text\": \"Device restarted\"}", 0, 0, 0);
+            publish_mqtt_message(client, "/a/restart", "", 0, 2, 1);
             sleep(3);
-            printf("%s\n", restart_cmd[1]);
-            esp_mqtt_client_publish(client,cmd_topic,"{\"status\": \"successful\"}", 0, 1, 1);
-            // ESP_LOGI(TAG, "sent successful successful, msg_id=%d", msg_id);
-            printf("sent successful successful.\n");
+            ESP_LOGI(TAG, "%s", restart_cmd[1]);
+            publish_mqtt_message(client, cmd_topic, "{\"status\": \"successful\"}", 0, 1, 1);
+            ESP_LOGI(TAG, "sent successful successful");
 
             if (cmd_topic != NULL)
                 {
@@ -228,16 +255,14 @@ static void mqtt_app_start(void)
                 }
             restart_cmd[0] = '\0';
             restart_cmd[1] = '\0';
-            printf("cmd 0 %d\n", restart_cmd[0]);
-            printf("cmd 1 %d\n", restart_cmd[1]);
+            ESP_LOGI(TAG, "cmd 0 %d", restart_cmd[0]);
+            ESP_LOGI(TAG, "cmd 1 %d", restart_cmd[1]);
             if (cmd_data != NULL)
                 {
-                    // printf("Point_4\n");
                     free(cmd_data);
                     cmd_data = NULL;
                 }
-            // printf("cmd 2 %d\n", restart_cmd[2]);
-            printf("Data cleared.");
+            ESP_LOGI(TAG, "Data cleared.");
             sleep(5);
         }
 


### PR DESCRIPTION
Use the wifi MAC address as the device's identity so that the same firmware image can be applied to multiple devices.


* Wrap mqtt publishing with a function which prefixes the device's identity
* Send event on device startup indicating which version
* Use ESP_LOGI statements instead of printf (for more consistent logging)