### PR TITLE
feat: auto discover thin-edge.io MQTT server using mdns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 sdkconfig
 sdkconfig.old
+managed_components/

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It based on the [ESP-MQTT sample application](https://github.com/espressif/esp-i
 
 ### Setting up the thin-edge.io device
 
-Since the ESP32 boadr needs to communicate with thin-edge.io over the network, the thin-edge.io instance needs to be setup to enable this communication.
+Since the ESP32 board needs to communicate with thin-edge.io over the network, the thin-edge.io instance needs to be setup to enable this communication.
 
 1. On the main device where the MQTT broker, tedge-mapper-c8y and tedge-agent, run the following commands to set the configuration:
 
@@ -71,19 +71,25 @@ You can also follow the [Getting Started](https://docs.espressif.com/projects/es
    Open EDF-IDF: SDK Configuration Editor. Under 'Example Connection Configuration' set Wi-Fi SSID and password 
    
    :warning: May need to repeat step 2-4 when you reopen VS Code
-5. Set MQTT Broker URI
-   Open main.c, set the MQTT Broker URI on line 180. Use the IP address of Raspberry Pi
-6. Optional: change device ID
-   You can change the device id. If you do so,do not forget change the device id in topics as well.
-   
-   :construction: Todo: Remove hardcoded topics
-7. Build image
-8. Select Flash Method
+5. Build image
+6. Select Flash Method
 
    For USB: UART
-9. Flash Device
+7. Flash Device
    Connect ESP32 Board to the PC, then flash device.
-10. Optional: monitor device
+8. Optional: monitor device
+
+## Troubleshooting
+
+### Microcontroller does not discover a valid thin-edge.io instance
+
+If you the microcontroller does not detect a thin-edge.io instance anywhere, then you are probably not using a thin-edge.io built using either [Rugpi](https://thin-edge.github.io/thin-edge.io/extend/firmware-management/building-image/rugpi/) or [Yocto](https://thin-edge.github.io/thin-edge.io/extend/firmware-management/building-image/yocto/), as these images will install an avahi service will make thin-edge.io auto discoverable to other devices in the local network.
+
+If you can't use on of the above images, then you can manually control which thin-edge.io the microcontroller will connect to by configuring the `MANUAL_MQTT_HOST` variable in the [main/main.c](main/main.c) file.
+
+```c
+const char *MANUAL_MQTT_HOST = "my-rpi-host";
+```
 
 
 Usage
@@ -94,4 +100,13 @@ Usage
    :construction: A restart command actually triggers two times of restarts. Maintenance in progress
 3. Create an alarm before restart
 4. Create an event after restart
+
+### Building does not pull in the correct dependencies
+
+If you encounter a build problem about some missing dependencies, e.g. `mdns.h`, then you may need to reconfigure the project to force idf to download the missing dependency. You can do this by running the following commands:
+
+```sh
+idf.py reconfigure
+idf.py build
+```
 

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -1,0 +1,15 @@
+dependencies:
+  espressif/mdns:
+    component_hash: d8ae7aa491ff97aea1d00d514a1de42cdbaaf1bce10df183968fa5594b904de7
+    source:
+      service_url: https://api.components.espressif.com/
+      type: service
+    version: 1.2.5
+  idf:
+    component_hash: null
+    source:
+      type: idf
+    version: 5.2.1
+manifest_hash: c48887084bb8cb4fd4d30b00878dc829857fc62dd90320fa1eca530da8bbaef0
+target: esp32
+version: 1.0.0

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,0 +1,19 @@
+## IDF Component Manager Manifest File
+dependencies:
+  # espressif/mdns: "^1.2.5"
+  espressif/mdns:
+    version: "^1.2.5"
+  ## Required IDF version
+  idf:
+    version: ">=5.0.0,<6.0.0"
+  # # Put list of dependencies here
+  # # For components maintained by Espressif:
+  # component: "~1.0.0"
+  # # For 3rd party components:
+  # username/component: ">=1.0.0,<2.0.0"
+  # username2/component2:
+  #   version: "~1.0.0"
+  #   # For transient dependencies `public` flag can be set.
+  #   # `public` flag doesn't have an effect dependencies of the `main` component.
+  #   # All dependencies of `main` are public by default.
+  #   public: true


### PR DESCRIPTION
Auto discover thin-edge.io MQTT broker via mdns (only works if you have used the rugpi or yocto image which includes the avahi service definition which enables this service discovery. The detected MQTT broker will then be saved to non-volatile memory (NVM) where it will be read on startup so that the discovery step is only done once.
