### PR TITLE
refactor: reorganize project to use tedge library

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,3 +1,3 @@
-idf_component_register(SRCS "main.c"
-                    INCLUDE_DIRS ".")
+idf_component_register(SRCS "main.c" "../tedge/src/tedge_command.c" "../tedge/src/tedge.c"
+                    INCLUDE_DIRS "." "../tedge/include")
 target_compile_options(${COMPONENT_LIB} PRIVATE "-Wno-format")

--- a/tedge/CMakeLists.txt
+++ b/tedge/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(include_dirs include ./include)
+list(APPEND srcs "src/tedge_command.c" "src/tedge.c")
+
+idf_component_register(SRCS "${srcs}"
+    INCLUDE_DIRS "${include_dirs}")
+
+target_compile_options(${COMPONENT_LIB} PRIVATE "-Wno-format")

--- a/tedge/include/tedge.h
+++ b/tedge/include/tedge.h
@@ -1,0 +1,6 @@
+#ifndef TEDGE_HDR_H
+#define TEDGE_HDR_H
+
+void tedge_banner(void);
+
+#endif

--- a/tedge/include/tedge_command.h
+++ b/tedge/include/tedge_command.h
@@ -1,0 +1,44 @@
+#ifndef TEDGE_HDR_COMMAND_H
+#define TEDGE_HDR_COMMAND_H
+
+#include "cJSON.h"
+
+void tedge_command_version(void);
+
+typedef enum
+{
+    TEDGE_COMMAND_STATUS_NONE = 0,
+    TEDGE_COMMAND_STATUS_INIT = 1,
+    TEDGE_COMMAND_STATUS_EXECUTING = 2,
+    TEDGE_COMMAND_STATUS_SUCCESSFUL = 3,
+    TEDGE_COMMAND_STATUS_FAILED = 4,
+} tedge_command_status_t;
+
+typedef enum
+{
+    TEDGE_COMMAND_NONE = 0,
+    TEDGE_COMMAND_RESTART = 1,
+    TEDGE_COMMAND_FIRMWARE_UPDATE = 2,
+} tedge_command_type_t;
+
+typedef struct Command
+{
+    tedge_command_type_t op_type;
+    tedge_command_status_t status;
+    char *id;
+    char *topic;
+    cJSON *payload;
+} tedge_command_t;
+
+const char *tedge_tedge_command_status_to_name(tedge_command_status_t);
+tedge_command_type_t tedge_command_get_type(char *);
+tedge_command_status_t tedge_command_get_status(cJSON *);
+const char *tedge_command_name(tedge_command_type_t);
+char *tedge_command_get_id(char *);
+void tedge_free_command(tedge_command_t *);
+void tedge_command_print(tedge_command_t *);
+
+void tedge_command_set_status(cJSON *, char *);
+void tedge_command_set_failed(cJSON *, char *);
+
+#endif

--- a/tedge/src/tedge.c
+++ b/tedge/src/tedge.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+#include "tedge.h"
+
+void tedge_banner(void)
+{
+    printf("\n----------------------------\ntedge app\n----------------------------\n\n");
+}

--- a/tedge/src/tedge_command.c
+++ b/tedge/src/tedge_command.c
@@ -1,0 +1,159 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "tedge_command.h"
+
+/*
+    Convert operation status to a human readable format
+*/
+const char *tedge_tedge_command_status_to_name(tedge_command_status_t code)
+{
+    switch (code)
+    {
+    case TEDGE_COMMAND_STATUS_NONE:
+        return "NONE";
+    case TEDGE_COMMAND_STATUS_INIT:
+        return "INIT";
+    case TEDGE_COMMAND_STATUS_EXECUTING:
+        return "EXECUTING";
+    case TEDGE_COMMAND_STATUS_SUCCESSFUL:
+        return "SUCCESSFUL";
+    case TEDGE_COMMAND_STATUS_FAILED:
+        return "FAILED";
+    }
+    return "NONE";
+}
+
+tedge_command_type_t tedge_command_get_type(char *topic)
+{
+    if (strstr(topic, "/cmd/restart/") != NULL)
+    {
+        return TEDGE_COMMAND_RESTART;
+    }
+    if (strstr(topic, "/cmd/firmware_update/") != NULL)
+    {
+        return TEDGE_COMMAND_FIRMWARE_UPDATE;
+    }
+    return TEDGE_COMMAND_NONE;
+}
+
+tedge_command_status_t tedge_command_get_status(cJSON *root)
+{
+    cJSON *statusObj = cJSON_GetObjectItem(root, "status");
+    char *statusStr = statusObj->valuestring;
+    tedge_command_status_t status = TEDGE_COMMAND_STATUS_NONE;
+
+    if (strcmp(statusStr, "init") == 0)
+    {
+        status = TEDGE_COMMAND_STATUS_INIT;
+    }
+    else if (strcmp(statusStr, "executing") == 0)
+    {
+        return TEDGE_COMMAND_STATUS_EXECUTING;
+    }
+    else if (strcmp(statusStr, "successful") == 0)
+    {
+        return TEDGE_COMMAND_STATUS_SUCCESSFUL;
+    }
+    else if (strcmp(statusStr, "failed") == 0)
+    {
+        return TEDGE_COMMAND_STATUS_FAILED;
+    }
+    return status;
+}
+
+/*
+    Convert operation type to a string
+*/
+const char *tedge_command_name(tedge_command_type_t code)
+{
+    switch (code)
+    {
+    case TEDGE_COMMAND_RESTART:
+        return "RESTART";
+    case TEDGE_COMMAND_FIRMWARE_UPDATE:
+        return "FIRMWARE_UPDATE";
+    default:
+        return "NONE";
+    }
+}
+
+char *tedge_command_get_id(char *topic)
+{
+    int end = (int)strlen(topic);
+    int x = 0;
+    char sep = '/';
+    for (x = end; x >= 0; --x)
+    {
+        if (topic[x] == sep)
+        {
+            char *value = calloc(64, sizeof(char));
+            strcpy(value, topic + x + 1);
+            return value;
+        }
+    }
+    return NULL;
+}
+
+/*
+    Free memory used by a command
+*/
+void tedge_free_command(tedge_command_t *cmd)
+{
+    if (cmd->payload != NULL)
+    {
+        cJSON_free(cmd->payload);
+        cmd->payload = NULL;
+    }
+    if (cmd->id != NULL)
+    {
+        free(cmd->id);
+        cmd->id = NULL;
+    }
+    if (cmd->topic != NULL)
+    {
+        free(cmd->topic);
+        cmd->topic = NULL;
+    }
+
+    cmd->status = TEDGE_COMMAND_STATUS_NONE;
+    cmd->op_type = TEDGE_COMMAND_NONE;
+}
+
+/*
+    Print command details
+*/
+void tedge_command_print(tedge_command_t *cmd)
+{
+    printf("------------------------- command -------------------------\n");
+    printf("TOPIC:     %s\n", cmd->topic);
+    printf("ID:        %s\n", cmd->id);
+    printf("STATUS:    %s\n", tedge_tedge_command_status_to_name(cmd->status));
+    char *payload = cJSON_Print(cmd->payload);
+    printf("PAYLOAD:   %s\n", payload);
+    free(payload);
+}
+
+/*
+    Set the command status
+*/
+void tedge_command_set_status(cJSON *payload, char *status)
+{
+    cJSON_SetValuestring(cJSON_GetObjectItem(payload, "status"), status);
+}
+
+/*
+    Set command to failed and add a failure reason
+*/
+void tedge_command_set_failed(cJSON *payload, char *reason)
+{
+    tedge_command_set_status(payload, "failed");
+    if (cJSON_HasObjectItem(payload, "reason"))
+    {
+        cJSON_SetValuestring(cJSON_GetObjectItem(payload, "reason"), reason);
+    }
+    else
+    {
+        cJSON_AddStringToObject(payload, "reason", reason);
+    }
+}


### PR DESCRIPTION
Refactor project to use local libraries (this is a best guess atm)

Eventually the tedge code could be moved out into an independent library.