### PR TITLE
ci: add build/release workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,70 @@
+on:
+  push:
+    branches:
+      - main
+      - ci-build-workflow
+    tags:
+      - "*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Note: Targets which requires a non-default rust_channel
+        # then they should not be included in the .target list, but
+        # rather in the include section.
+        # This is just how Github processes matrix jobs
+        target:
+          - esp32
+          - esp32s2
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
+
+    - name: esp-idf build
+      uses: espressif/esp-idf-ci-action@v1
+      with:
+        esp_idf_version: v5.2
+        target: ${{ matrix.target }}
+        path: ./
+        command: idf.py build
+
+    - name: Check build files
+      run: |
+        ls -l build
+
+    - name: Upload
+      uses: actions/upload-artifact@v4
+      with:
+          name: tedge-freertos-esp32-client_${{ matrix.target }}
+          path: build/freertos-esp32-client.bin
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    needs:
+      - build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: release
+      - name: Show release artifacts
+        run: ls -l release/*/*
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          generate_release_notes: true
+          draft: true
+          files: |
+            ./release/*.bin
+            ./release/*/*.bin

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,14 +1,43 @@
+permissions:
+  contents: write
 on:
   push:
     branches:
       - main
-      - ci-build-workflow
     tags:
       - "*"
 
 jobs:
+  info:
+    name: Build information
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.info.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: taiki-e/install-action@just
+      - id: info
+        name: Get Version
+        run: |
+          case "${GITHUB_REF}" in
+            refs/tags/*)
+              version="${GITHUB_REF#refs/*/}"
+              echo "Using version from tag: $version"
+              ;;
+            *)
+              version="$(just version)"
+              echo "Using version from timestamp: $version"
+              ;;
+          esac
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
   build:
     runs-on: ubuntu-latest
+    needs:
+      - info
     strategy:
       fail-fast: false
       matrix:
@@ -34,21 +63,23 @@ jobs:
         path: ./
         command: idf.py build
 
-    - name: Check build files
+    - name: Rename build file
       run: |
         ls -l build
+        sudo mv build/freertos-esp32-client.bin "build/freertos-esp32-client-${{ matrix.target }}_${{ needs.info.outputs.version }}.bin"
 
     - name: Upload
       uses: actions/upload-artifact@v4
       with:
-          name: tedge-freertos-esp32-client_${{ matrix.target }}
-          path: build/freertos-esp32-client.bin
+          name: tedge-freertos-esp32-client-${{ matrix.target }}_${{ needs.info.outputs.version }}
+          path: build/freertos-esp32-client-${{ matrix.target }}*.bin
 
   release:
     name: Release
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     needs:
+      - info
       - build
     steps:
       - name: Checkout

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,28 @@
+name: Deploy to Cumulocity
+on:
+  workflow_dispatch:
+  release:
+    types:
+      # Trigger on both prereleases and official releases
+      - published
+
+jobs:
+  deploy:
+    name: Publish to firmware repository
+    runs-on: ubuntu-latest
+    env:
+      C8Y_HOST: '${{ secrets.C8Y_HOST }}'
+      C8Y_USER: '${{ secrets.C8Y_USER }}'
+      C8Y_PASSWORD: '${{ secrets.C8Y_PASSWORD }}'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: taiki-e/install-action@just
+      - uses: reubenmiller/setup-go-c8y-cli@main
+      - run: |
+          echo "Name: ${{ github.event.release.name }} Description: ${{ github.event.release.body }}"
+          just publish-external ${{ github.event.release.name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/justfile
+++ b/justfile
@@ -1,0 +1,23 @@
+set dotenv-load
+
+export VERSION := env_var_or_default("VERSION", `date +'%Y%m%d.%H%M'`)
+
+# Generate a version name (that can be used in follow up commands)
+version:
+    @echo "{{VERSION}}"
+
+# Publish latest image to Cumulocity
+publish:
+    cd {{justfile_directory()}} && ./scripts/upload-c8y.sh
+
+# Publish a given github release to Cumulocity (using external urls)
+publish-external tag *args="":
+    cd {{justfile_directory()}} && ./scripts/c8y-publish-release.sh {{tag}} {{args}}
+
+# Trigger a release (by creating a tag)
+release:
+    git tag -a "{{VERSION}}" -m "{{VERSION}}"
+    git push origin "{{VERSION}}"
+    @echo
+    @echo "Created release (tag): {{VERSION}}"
+    @echo

--- a/scripts/c8y-publish-release.sh
+++ b/scripts/c8y-publish-release.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+#
+# Publish a release by creating the firmware and versions in Cumulocity
+# and link to the github artifact (rather than hosting the artifact in c8y itself)
+#
+# Dependencies:
+# * gh
+# * go-c8y-cli
+#
+
+set -e
+
+help() {
+    cat << EOT
+Publish github releases
+
+USAGE
+    $0 <TAG> [OPTIONS]
+
+FLAGS
+    --pre-release       Publish release as a pre-release (only if it set to draft)
+
+EXAMPLES
+    $0 1.0.0 --pre-release
+
+EOT
+}
+
+# Defaults
+PRE_RELEASE=0
+
+# Parse arguments
+REST_ARGS=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -h|--help)
+            help
+            exit 0
+            ;;
+
+        --pre-release)
+            PRE_RELEASE=1
+            ;;
+
+        *)
+            REST_ARGS+=("$1")
+            ;;
+    esac
+    shift
+done
+
+# Only set if rest arguments are defined
+if [ ${#REST_ARGS[@]} -gt 0 ]; then
+    set -- "${REST_ARGS[@]}"
+fi
+
+TAG=
+if [ $# -eq 0 ]; then
+    echo "Missing required argument" >&2
+    help
+    exit 1
+fi
+TAG="$1"
+
+publish_version() {
+    url="$1"
+    filename=$(basename "$url")
+    VERSION=$(echo "$filename" | sed 's/.img.xz$//' | rev | cut -d_ -f1 | rev)
+    NAME=$(echo "$filename" | rev | cut -d_ -f2- | rev)
+    DEVICE_TYPE=$NAME
+    #echo "name=$NAME, version=$VERSION, url=$url" >&2
+
+    if [ -z "$NAME" ] || [ -z "$VERSION" ] || [ -z "$url" ]; then
+        echo "Missing required information. Non empty values are required for name, version and url" >&2
+        return 1
+    fi
+
+    if [ -n "$NAME" ] && [ -n "$VERSION" ] && [ -n "$url" ]; then
+        # Create/Update firmware name (if it does not already exist)
+        if c8y firmware get -n --id "$NAME"  >/dev/null 2>&1; then
+            c8y firmware update -n --id "$NAME" --deviceType "$DEVICE_TYPE" --delay "1s" --force 
+        else
+            c8y firmware create -n --name "$NAME" --deviceType "$DEVICE_TYPE" --delay "1s" --force
+        fi
+        # create version if it does not already exist
+        if ! c8y firmware versions get -n --firmware "$NAME" --id "$VERSION" >/dev/null 2>&1; then
+            c8y firmware versions create -n --firmware "$NAME" --version "$VERSION" --url "$url" --force
+        else
+            echo "Version already exists. firmware=$NAME, version=$VERSION, url=$url" >&2
+        fi
+    fi
+}
+
+wait_for_released() {
+    #
+    # Wait for a Github release to transition away from the draft state (e.g. either prerelease or release)
+    #
+    tag="$1"
+    retries=5
+    attempt=0
+
+    # Note: using exit/return code convention, 1=not ok, 0=ok
+    success=1
+    while [ "$attempt" -lt "$retries" ]; do
+        if [ "$(gh release view "$tag" --json isDraft  --template "{{.isDraft}}")" = "false" ]; then
+            success=0
+            break
+        fi
+        attempt=$((attempt + 1))
+        echo "Waiting for release to be released..." >&2
+        sleep 3
+    done
+    return "$success"
+}
+
+# Set from draft to pre-release
+if [ "$PRE_RELEASE" = 1 ]; then
+    IS_DRAFT=$(gh release view "$TAG" --json isDraft  --template "{{.isDraft}}")
+    if [ "$IS_DRAFT" = "true" ]; then
+        echo "Update $TAG to prerelease."
+        gh release edit --draft=false --prerelease "$TAG"
+        if ! wait_for_released "$TAG"; then
+            echo "Could not update $TAG to prerelease. Exiting"
+            exit 5
+        fi
+    fi
+fi
+# Get assets from given tag
+FILES=$(gh release view "$TAG" --json assets --jq '.assets[].url' | grep ".xz")
+
+# publish each version found
+for file in $FILES; do
+    publish_version "$file"
+done

--- a/scripts/update-c8y.sh
+++ b/scripts/update-c8y.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -e
+LATEST=
+
+if [ $# -gt 0 ]; then
+    LATEST="$1"
+fi
+
+unset -v LATEST
+for file in "build"/*; do
+  [[ "$file" -nt "$LATEST" ]] && LATEST=$file
+done
+
+FIRMWARE_NAME=$(basename "$LATEST" | rev | cut -d_ -f2- | rev)
+VERSION=$(echo "$LATEST" | sed 's/.*_//g' | sed 's/.img.xz//g')
+
+if [ -z "$VERSION" ]; then
+    echo "Could not detect version"
+    exit
+fi
+
+c8y firmware get --id "$FIRMWARE_NAME" 2>/dev/null || {
+    echo "Creating firmware: $FIRMWARE_NAME"
+    c8y firmware create --name "$FIRMWARE_NAME"
+}
+
+c8y firmware versions create --firmware "$FIRMWARE_NAME" --file "$LATEST" --version "$VERSION"


### PR DESCRIPTION
Add a build and release workflow to build the firmware for different target esp32 variants and create a draft release on tagging.

Note: The produced firmware images might not yet work due to the default wifi credentials. It must still be tested if these images can be applied to a device without overwriting the originally configured wifi credentials (whoever this is out of scope for this PR)