### PR TITLE
ci: add name to build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,3 +1,4 @@
+name: build
 permissions:
   contents: write
 on:


### PR DESCRIPTION
Name the build workflow so it is easier to identify in the github workflows UI